### PR TITLE
Add File Mode Quotation rule

### DIFF
--- a/lib/saltlint/rules/FileModeQuotationRule.py
+++ b/lib/saltlint/rules/FileModeQuotationRule.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2016, Will Thames and contributors
+# Copyright (c) 2018, Ansible Project
+# Modified work Copyright (c) 2019 Jeffrey Bouter
+
+from saltlint import SaltLintRule
+import re
+
+
+class FileModeQuotationRule(SaltLintRule):
+    id = '207'
+    shortdesc = 'File modes should always be encapsulated in quotation marks'
+    description = 'File modes should always be encapsulated in quotation marks'
+    severity = 'HIGH'
+    tags = ['formatting']
+    version_added = 'v0.0.1'
+
+    bracket_regex = re.compile(r"^\s+- ((dir_)|(file_))?mode: [0-9]{3,4}")
+
+    def match(self, file, line):
+        return self.bracket_regex.search(line)

--- a/tests/unit/TestFileModeQuotationRule.py
+++ b/tests/unit/TestFileModeQuotationRule.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2013-2018 Will Thames <will@thames.id.au>
+# Copyright (c) 2018 Ansible by Red Hat
+# Modified work Copyright (c) 2019 Jeffrey Bouter
+
+import unittest
+
+from saltlint import RulesCollection
+from saltlint.rules.FileModeQuotationRule import FileModeQuotationRule
+from tests import RunFromText
+
+
+GOOD_MODE_QUOTATION_LINE = '''
+testfile:
+  file.managed:
+    - name: /tmp/testfile
+    - user: root
+    - group: root
+    - mode: '0700'
+'''
+
+BAD_MODE_QUOTATION_LINE = '''
+testfile:
+  file.managed:
+    - name: /tmp/badfile
+    - user: root
+    - group: root
+    - mode: 0700
+    - file_mode: 0660
+    - dir_mode: 0775
+'''
+
+class TestLineTooLongRule(unittest.TestCase):
+    collection = RulesCollection()
+
+    def setUp(self):
+        self.collection.register(FileModeQuotationRule())
+        self.runner = RunFromText(self.collection)
+
+    def test_statement_positive(self):
+        results = self.runner.run_state(GOOD_MODE_QUOTATION_LINE)
+        self.assertEqual(0, len(results))
+
+    def test_statement_negative(self):
+        results = self.runner.run_state(BAD_MODE_QUOTATION_LINE)
+        self.assertEqual(3, len(results))


### PR DESCRIPTION
- Add a rule to check for file modes. Supports:
  - mode
  - file_mode
  - dir_mode

Fixes #5 