### PR TITLE
fix(jinja_variables): use same base regex as Jinja statements

### DIFF
--- a/lib/saltlint/rules/JinjaVariableHasSpacesRule.py
+++ b/lib/saltlint/rules/JinjaVariableHasSpacesRule.py
@@ -14,7 +14,7 @@ class JinjaVariableHasSpacesRule(SaltLintRule):
     tags = ['formatting']
     version_added = 'v0.0.1'
 
-    bracket_regex = re.compile(r"{{[^ ]|[^ ]}}")
+    bracket_regex = re.compile(r"{{[^ -]|{{-[^ ]|[^ -]}}|[^ ]-}}")
 
     def match(self, file, line):
         return self.bracket_regex.search(line)

--- a/tests/unit/TestJinjaVariableHasSpaces.py
+++ b/tests/unit/TestJinjaVariableHasSpaces.py
@@ -10,11 +10,11 @@ from tests import RunFromText
 
 
 GOOD_VARIABLE_LINE = '''
-{{ variable }}
+{{- variable -}}
 '''
 
 BAD_VARIABLE_LINE = '''
-{{ variable}}
+{{-variable-}}
 '''
 
 class TestLineTooLongRule(unittest.TestCase):


### PR DESCRIPTION
* https://jinja.palletsprojects.com/en/2.10.x/templates/#whitespace-control
  - If you add a minus sign (-) to the start or end of a block
    (e.g. a For tag), a comment, or a variable expression,
    the whitespaces before or after that block will be removed
* Example from SaltStack-Formulas:
  - https://travis-ci.org/myii/php-formula/jobs/593649688#L464-L466
  - This particurlar invocation is used in numerous formulas