### PR TITLE
feat(jinja_comments): lint in the same way as statements and variables

### DIFF
--- a/lib/saltlint/rules/JinjaCommentHasSpacesRule.py
+++ b/lib/saltlint/rules/JinjaCommentHasSpacesRule.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2016, Will Thames and contributors
+# Copyright (c) 2018, Ansible Project
+# Modified work Copyright (c) 2019 Roald Nefs
+
+from saltlint import SaltLintRule
+import re
+
+
+class JinjaCommentHasSpacesRule(SaltLintRule):
+    id = '209'
+    shortdesc = 'Jinja comment should have spaces before and after: {# comment #}'
+    description = 'Jinja comment should have spaces before and after: ``{# comment #}``'
+    severity = 'LOW'
+    tags = ['formatting']
+    version_added = 'v0.0.5'
+
+    bracket_regex = re.compile(r"{#[^ -]|{#-[^ ]|[^ -]#}|[^ ]-#}")
+
+    def match(self, file, line):
+        return self.bracket_regex.search(line)

--- a/tests/unit/TestJinjaCommentHasSpaces.py
+++ b/tests/unit/TestJinjaCommentHasSpaces.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2013-2018 Will Thames <will@thames.id.au>
+# Copyright (c) 2018 Ansible by Red Hat
+# Modified work Copyright (c) 2019 Roald Nefs
+
+import unittest
+
+from saltlint import RulesCollection
+from saltlint.rules.JinjaCommentHasSpacesRule import JinjaCommentHasSpacesRule
+from tests import RunFromText
+
+
+GOOD_COMMENT_LINE = '''
+{#- set example='good' -#}
+'''
+
+BAD_COMMENT_LINE = '''
+{#-set example='bad'-#}
+'''
+
+class TestLineTooLongRule(unittest.TestCase):
+    collection = RulesCollection()
+
+    def setUp(self):
+        self.collection.register(JinjaCommentHasSpacesRule())
+        self.runner = RunFromText(self.collection)
+
+    def test_comment_positive(self):
+        results = self.runner.run_state(GOOD_COMMENT_LINE)
+        self.assertEqual(0, len(results))
+
+    def test_comment_negative(self):
+        results = self.runner.run_state(BAD_COMMENT_LINE)
+        self.assertEqual(1, len(results))


### PR DESCRIPTION
* Related to #13
* https://jinja.palletsprojects.com/en/2.10.x/templates/#whitespace-control
  - If you add a minus sign (-) to the start or end of a block
    (e.g. a For tag), a comment, or a variable expression,
    the whitespaces before or after that block will be removed