### PR TITLE
Add YamlHasOctalValueRule

### DIFF
--- a/lib/saltlint/rules/YamlHasOctalValueRule.py
+++ b/lib/saltlint/rules/YamlHasOctalValueRule.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2016, Will Thames and contributors
+# Copyright (c) 2018, Ansible Project
+# Modified work Copyright (c) 2019 Roald Nefs
+
+from saltlint import SaltLintRule
+import re
+
+
+class YamlHasOctalValueRule(SaltLintRule):
+    id = '210'
+    shortdesc = 'Numbers that start with `0` should always be encapsulated in quotation marks'
+    description = 'Numbers that start with `0` should always be encapsulated in quotation marks'
+    severity = 'HIGH'
+    tags = ['formatting']
+    version_added = 'develop'
+
+    bracket_regex = re.compile(r"(?<!['\"])0+[1-9]\d*(?!['\"])")
+
+    def match(self, file, line):
+        return self.bracket_regex.search(line)

--- a/tests/unit/TestYamlHasOctalValueRule.py
+++ b/tests/unit/TestYamlHasOctalValueRule.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2013-2018 Will Thames <will@thames.id.au>
+# Copyright (c) 2018 Ansible by Red Hat
+# Modified work Copyright (c) 2019 Roald Nefs
+
+import unittest
+
+from saltlint import RulesCollection
+from saltlint.rules.YamlHasOctalValueRule import YamlHasOctalValueRule
+from tests import RunFromText
+
+
+GOOD_NUMBER_LINE = '''
+testdirectory:
+  file.recurse:
+    - name: /tmp/directory
+    - file_mode: 700
+    - dir_mode: '0775'
+
+testdirectory2:
+  file.recurse:
+    - name: /tmp/directory2
+    - file_mode: 0
+    - dir_mode: "0775"
+'''
+
+BAD_NUMBER_LINE = '''
+testdirectory:
+  file.recurse:
+    - name: /tmp/directory
+    - file_mode: 0775
+    - dir_mode: 070
+'''
+
+class TestFileModeLeadingZeroRule(unittest.TestCase):
+    collection = RulesCollection()
+
+    def setUp(self):
+        self.collection.register(YamlHasOctalValueRule())
+
+    def test_statement_positive(self):
+        runner = RunFromText(self.collection)
+        results = runner.run_state(GOOD_NUMBER_LINE)
+        self.assertEqual(0, len(results))
+
+    def test_statement_negative(self):
+        runner = RunFromText(self.collection)
+        results = runner.run_state(BAD_NUMBER_LINE)
+        self.assertEqual(2, len(results))


### PR DESCRIPTION
Add rule (`YamlHasOctalValueRule`) to check on unquoted octal values.  When using a numeric value that includes a leading zero you must wrap the value in quotes. If the value is not wrapped in quotes it will be read by YAML as an integer and evaluated as an octal.

Fixes #29.