### PR TITLE
Fix YamlHasOctalValueRule

### DIFF
--- a/lib/saltlint/rules/YamlHasOctalValueRule.py
+++ b/lib/saltlint/rules/YamlHasOctalValueRule.py
@@ -14,7 +14,7 @@ class YamlHasOctalValueRule(SaltLintRule):
     tags = ['formatting']
     version_added = 'v0.0.6'
 
-    bracket_regex = re.compile(r"(?<!['\"])0+[1-9]\d*(?!['\"])")
+    bracket_regex = re.compile(r": (?<!['\"])0+[1-9]\d*(?!['\"])")
 
     def match(self, file, line):
         return self.bracket_regex.search(line)

--- a/tests/unit/TestYamlHasOctalValueRule.py
+++ b/tests/unit/TestYamlHasOctalValueRule.py
@@ -16,9 +16,9 @@ testdirectory:
     - file_mode: 700
     - dir_mode: '0775'
 
-testdirectory2:
+testdirectory02:
   file.recurse:
-    - name: /tmp/directory2
+    - name: /tmp/directory02
     - file_mode: 0
     - dir_mode: "0775"
 '''


### PR DESCRIPTION
Fix `YamlHasOctalValueRule` to only trigger after `: ` entries. Otherwise `example010` would also trigger.

Fixes #34.