### PR TITLE
Fix octal values

### DIFF
--- a/lib/saltlint/rules/YamlHasOctalValueRule.py
+++ b/lib/saltlint/rules/YamlHasOctalValueRule.py
@@ -14,7 +14,7 @@ class YamlHasOctalValueRule(SaltLintRule):
     tags = ['formatting']
     version_added = 'v0.0.6'
 
-    bracket_regex = re.compile(r": (?<!['\"])0+[1-9]\d*(?!['\"])")
+    bracket_regex = re.compile(r": (?<!['\"])0+[0-9]\d*(?!['\"])")
 
     def match(self, file, line):
         return self.bracket_regex.search(line)

--- a/tests/unit/TestYamlHasOctalValueRule.py
+++ b/tests/unit/TestYamlHasOctalValueRule.py
@@ -26,9 +26,10 @@ testdirectory02:
 BAD_NUMBER_LINE = '''
 testdirectory:
   file.recurse:
-    - name: /tmp/directory
-    - file_mode: 0775
-    - dir_mode: 070
+    - name: /tmp/directory001  # shouldn't fail
+    - mode: 0                  # shouldn't fail
+    - file_mode: 00            # should fail
+    - dir_mode: 0700           # should fail
 '''
 
 class TestFileModeLeadingZeroRule(unittest.TestCase):


### PR DESCRIPTION
Yaml also interpret any sequence of zeros (i.e. 00, 000, 0000, etc.) as an octal value.

For more information see: https://github.com/roaldnefs/salt-lint/pull/31#issuecomment-538950630.