### PR TITLE
WIP: Add initial CmdWaitRule

### DIFF
--- a/lib/saltlint/__init__.py
+++ b/lib/saltlint/__init__.py
@@ -80,7 +80,7 @@ class SaltLintRule(object):
         with warnings.catch_warnings(record=True) as warn_list:
             try:
                 yaml = yamlloader.load(text)
-            except ScannerError as exc:
+            except ScannerError as exc:  # noqa: F841
                 # err_type = _ERROR_MAP.get(exc.problem, exc.problem)
                 # line_num = exc.problem_mark.line + 1
                 # TODO do something with exeception

--- a/lib/saltlint/__init__.py
+++ b/lib/saltlint/__init__.py
@@ -20,7 +20,7 @@ import saltlint.utils
 
 # Import salt libs
 from salt.utils import yamlloader
-from salt.renderers.yaml import _ERROR_MAP
+from salt.renderers.yaml import _ERROR_MAP  # noqa: F401
 
 default_rulesdir = os.path.join(os.path.dirname(saltlint.utils.__file__), 'rules')
 
@@ -75,28 +75,32 @@ class SaltLintRule(object):
 
         # Strip jinja from the statefile text
         text = self.unjinja(text)
+        yaml = {}
 
         with warnings.catch_warnings(record=True) as warn_list:
             try:
                 yaml = yamlloader.load(text)
             except ScannerError as exc:
-                err_type = _ERROR_MAP.get(exc.problem, exc.problem)
-                line_num = exc.problem_mark.line + 1
+                # err_type = _ERROR_MAP.get(exc.problem, exc.problem)
+                # line_num = exc.problem_mark.line + 1
                 # TODO do something with exeception
-            except (ParserError, ConstructorError) as exc:
                 pass
+            except (ParserError, ConstructorError) as exc:  # noqa: F841
                 # TODO do something with exeception
+                pass
 
             if len(warn_list) > 0:
                 for item in warn_list:
                     # TODO do something with warngin
                     pass
 
-            # Get the result
+            # Get the result based on the parsed YAML
             result = self.matchyaml(file, yaml)
 
             for section, message in result:
-                matches.append(Match('?', section, file['path'], self, message))
+                # TODO fix line number, because after parsing YAML we lost the lines
+                line_number = '?'
+                matches.append(Match(line_number, section, file['path'], self, message))
 
             return matches
 

--- a/lib/saltlint/rules/CmdWaitRule.py
+++ b/lib/saltlint/rules/CmdWaitRule.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
-# Copyright (c) 2018, Ansible Project
-# Modified work Copyright (c) 2019 Roald Nefs
+# Copyright (c) 2019 Roald Nefs
 
 from saltlint import SaltLintRule
 

--- a/lib/saltlint/rules/CmdWaitRule.py
+++ b/lib/saltlint/rules/CmdWaitRule.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
+# Copyright (c) 2018, Ansible Project
+# Modified work Copyright (c) 2019 Roald Nefs
+
+from saltlint import SaltLintRule
+
+import os
+import six
+
+
+class CmdWaitRule(SaltLintRule):
+    id = '100'
+    shortdesc = 'Use ``cmd.run`` together with ``onchanges`` instead of ``cmd.wait``.'
+    description = 'Use ``cmd.run`` together with ``onchanges`` instead of ``cmd.wait``.'
+    severity = 'HIGH'
+    tags = ['formatting']
+    version_added = 'develop'
+
+    def matchyaml(self, file, yaml):
+        results = []
+
+        for state_id, state in six.iteritems(yaml):
+            if isinstance(state, dict):
+                for key, value in six.iteritems(state):
+                    if key == 'cmd.wait':
+                        results.append(('In state with ID: {}'.format(state_id), self.description))
+                        print('cmd.wait FOUND!')
+
+                    if key == 'cmd':
+                        if isinstance(value, list):
+                            for entry in value:
+                                if entry == 'wait':
+                                    results.append((('In state with ID: {}'.format(state_id), self.description))
+
+        return results

--- a/lib/saltlint/rules/CmdWaitRule.py
+++ b/lib/saltlint/rules/CmdWaitRule.py
@@ -4,7 +4,6 @@
 
 from saltlint import SaltLintRule
 
-import os
 import six
 
 
@@ -19,17 +18,32 @@ class CmdWaitRule(SaltLintRule):
     def matchyaml(self, file, yaml):
         results = []
 
-        for state_id, state in six.iteritems(yaml):
-            if isinstance(state, dict):
-                for key, value in six.iteritems(state):
-                    if key == 'cmd.wait':
-                        results.append(('In state with ID: {}'.format(state_id), self.description))
-                        print('cmd.wait FOUND!')
+        if not isinstance(yaml, dict):
+            return results
 
-                    if key == 'cmd':
-                        if isinstance(value, list):
-                            for entry in value:
-                                if entry == 'wait':
-                                    results.append((('In state with ID: {}'.format(state_id), self.description))
+        # Loop over the individual states
+        for state_id, state in six.iteritems(yaml):
+            # Skip entries that aren't a dictionary
+            if not isinstance(state, dict):
+                continue
+
+            # Loop over key, value pairs in the state
+            for key, value in six.iteritems(state):
+
+                # Match inline function
+                if key == 'cmd.wait':
+                    results.append((
+                        'In state with ID: {}'.format(state_id),
+                        self.description)
+                    )
+
+                # Match standard state declaration
+                if key == 'cmd' and isinstance(value, list):
+                    # Look for the 'wait' function
+                    if 'wait' in value:
+                        results.append((
+                            'In state with ID: {}'.format(state_id),
+                            self.description)
+                        )
 
         return results

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
 requirements = [
     'salt',
     'six',
-    'pyyaml',
 ]
 
 if sys.argv[-1] == 'readme':


### PR DESCRIPTION
Add initial CmdWaitRule to check becuase ``cmd.run`` should be used together with ``onchanges`` instead of ``cmd.wait``.

According to the [salt.states.cmd.wait](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.cmd.html#salt.states.cmd.wait) documentation:

> Note: Use cmd.run together with onchanges instead of cmd.wait.

This commit also deletes `pyyaml` as a dependency, because we now use the yaml libs of salt itself.