### PR TITLE
Remove six and pyyaml as dependency

### DIFF
--- a/lib/saltlint/__init__.py
+++ b/lib/saltlint/__init__.py
@@ -7,11 +7,13 @@ from collections import defaultdict
 import os
 import re
 import sys
+import codecs
 
-import six
+# import Salt libs
+from salt.ext import six
 
 import saltlint.utils
-import codecs
+
 
 default_rulesdir = os.path.join(os.path.dirname(saltlint.utils.__file__), 'rules')
 

--- a/lib/saltlint/__main__.py
+++ b/lib/saltlint/__main__.py
@@ -8,14 +8,16 @@ from __future__ import print_function
 import errno
 import optparse
 import sys
+import yaml
+import os
+
+# import Salt libs
+from salt.ext import six
 
 import saltlint
 import saltlint.formatters as formatters
-import six
 from saltlint import RulesCollection
 from saltlint.version import __version__
-import yaml
-import os
 
 
 def load_config(config_file):

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
 
 requirements = [
     'salt',
-    'six',
-    'pyyaml',
 ]
 
 if sys.argv[-1] == 'readme':


### PR DESCRIPTION
Remove `six` and` pyyaml` as dependency, because they are already installed by `salt`.

Fixes the following error message during install of salt-lint:

> ERROR: salt 2019.2.1 has requirement PyYAML<5.1, but you'll have pyyaml 5.1.2 which is incompatible.