### PR TITLE
Add option to run rules that use the full text

### DIFF
--- a/lib/saltlint/__init__.py
+++ b/lib/saltlint/__init__.py
@@ -27,6 +27,7 @@ class SaltLintRule(object):
         return self.id + ": " + self.shortdesc + "\n " + self.description
 
     match = None
+    matchtext = None
 
     @staticmethod
     def unjinja(text):
@@ -55,6 +56,18 @@ class SaltLintRule(object):
                 message = result
             matches.append(Match(prev_line_no+1, line,
                            file['path'], self, message))
+
+        return matches
+
+    def matchfulltext(self, file, text):
+        matches = []
+        if not self.matchtext:
+            return matches
+
+        results = self.matchtext(file, text)
+
+        for line, section, message in results:
+            matches.append(Match(line, section, file['path'], self, message))
 
         return matches
 
@@ -95,6 +108,7 @@ class RulesCollection(object):
                 rule_definition.add(rule.id)
                 if set(rule_definition).isdisjoint(skip_list):
                     matches.extend(rule.matchlines(statefile, text))
+                    matches.extend(rule.matchfulltext(statefile, text))
 
         return matches
 


### PR DESCRIPTION
Add option to run rules that use the full (raw) text of the input file instead of line by line.

Example rule:
```python
class TestRule(SaltLintRule):
    id = '999'
    shortdesc = 'Example rule that receives the full text'
    description = 'Example rule that receives the full text of the state'
    severity = 'LOW'
    tags = ['example']
    version_added = 'develop'

    def matchtext(self, file, text):
        results = []
        results.append((999, 'section', self.shortdesc))
        return results
```

Result in the following output:
```
[999] Example rule that receives the full text
tests/test-extension-success.sls:999
section
```

This is especially useful after implementing #52, because users could now implement rules that use the full raw text.